### PR TITLE
Implemented feedbacks from previous PR - backend (seatbid)

### DIFF
--- a/backend/websocket.js
+++ b/backend/websocket.js
@@ -1,9 +1,31 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
 /**
  * In-memory storage for active biddings and bids associated with each bidding
  * @type {Map}
  */
 export const activeBiddings = new Map();
 export const bids = new Map();
+
+/**
+ * Check if a user still owns a specific seat
+ * @param {string} flightId - The ID of the flight
+ * @param {string} userId - The ID of the user
+ * @param {string} seatNumber - The seat number to check
+ * @param {string} expectedSeatNumber - The seat number we expect the user to own.
+ * @returns {Object} An object containing:
+ *   - ownsExpectedSeat (boolean): True if the user's current seat matches the expected seat, false otherwise.
+ */
+export async function checkSeatOwnership(flightId, userId, expectedSeatNumber) {
+    const passenger = await prisma.passenger.findUnique({
+        where: {
+            flightId_userId: { flightId, userId },
+        },
+    });
+    return passenger?.seatNumber === expectedSeatNumber;
+}
 
 /**
  * Set up WebSocket connection and event handlers


### PR DESCRIPTION
### **Update Seat Bidding Backend Logic**

### Key Changes:

1. Implemented seat ownership verification in `/accept` route
	* Added checkSeatOwnership function calls for both initiator and bidder
	* Checks if both the bidding initiator and accepted bidder still own their seats
	* Prevents invalid seat swaps due to outdated ownership information
3. Optimized bidding cleanup after seat swaps
	* Removes related bids and biddings for swapped seats
	* Updates other active biddings to remove invalid bids
4. Added new 'biddings-removed' event emission
	* Informs clients about removed biddings and affected seat numbers
	* Helps maintain consistency across all connected clients

### Testing
https://www.loom.com/share/8a75602c7b8c43989808902e45fd4e02
