### PR TITLE
Fixed auth-check error before loggin in

### DIFF
--- a/frontend/src/Components/ProtectedRoute.jsx
+++ b/frontend/src/Components/ProtectedRoute.jsx
@@ -12,8 +12,7 @@ const [error, setError] = useState(null);
 
 useEffect(() => {
     const checkAuth = async () => {
-        if (user === null){
-            setIsLoading(true);
+        if (user !== null){
             try {
                 const response = await fetch(`${API_BASE_URL}/users/auth-check`, {
                 credentials: 'include'


### PR DESCRIPTION
### **Fixed auth-check error before loggin in**

When a user first lands on the login page, it was checking for authentication even though the user didn't login. This issue occurred because of a small nit in ProtectedRoute.jsx file which is fixed here.

**Testing**

https://github.com/user-attachments/assets/04ac9c48-69d2-4570-9184-db09f1e8537c

