### PR TITLE
Added models in schema for bidding

### DIFF
--- a/backend/prisma/migrations/20240725144919_bidding_tables/migration.sql
+++ b/backend/prisma/migrations/20240725144919_bidding_tables/migration.sql
@@ -1,0 +1,45 @@
+/*
+  Warnings:
+
+  - Added the required column `scheduledDepartureTime` to the `Flight` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Flight" ADD COLUMN     "scheduledDepartureTime" TEXT NOT NULL;
+
+-- CreateTable
+CREATE TABLE "Bidding" (
+    "biddingId" TEXT NOT NULL,
+    "flightId" TEXT NOT NULL,
+    "passengerId" INTEGER NOT NULL,
+    "seatNumber" TEXT NOT NULL,
+    "startTime" TIMESTAMP(3) NOT NULL,
+    "expirationTime" TIMESTAMP(3) NOT NULL,
+    "status" TEXT NOT NULL,
+
+    CONSTRAINT "Bidding_pkey" PRIMARY KEY ("biddingId")
+);
+
+-- CreateTable
+CREATE TABLE "Bid" (
+    "bidId" SERIAL NOT NULL,
+    "biddingId" TEXT NOT NULL,
+    "bidderId" INTEGER NOT NULL,
+    "amount" DOUBLE PRECISION NOT NULL,
+    "bidderSeatNumber" TEXT NOT NULL,
+    "time" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Bid_pkey" PRIMARY KEY ("bidId")
+);
+
+-- AddForeignKey
+ALTER TABLE "Bidding" ADD CONSTRAINT "Bidding_flightId_fkey" FOREIGN KEY ("flightId") REFERENCES "Flight"("flightId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Bidding" ADD CONSTRAINT "Bidding_passengerId_fkey" FOREIGN KEY ("passengerId") REFERENCES "Passenger"("passengerId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Bid" ADD CONSTRAINT "Bid_biddingId_fkey" FOREIGN KEY ("biddingId") REFERENCES "Bidding"("biddingId") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Bid" ADD CONSTRAINT "Bid_bidderId_fkey" FOREIGN KEY ("bidderId") REFERENCES "Passenger"("passengerId") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -49,7 +49,9 @@ model Flight {
   carrierCode           String
   flightNumber          Int
   scheduledDepartureDate String
+  scheduledDepartureTime String
   passengers            Passenger[]
+  biddings              Bidding[]
 
   @@unique([carrierCode, flightNumber, scheduledDepartureDate])
 }
@@ -61,9 +63,34 @@ model Passenger {
   flightId              String
   flight                Flight   @relation(fields: [flightId], references: [flightId])
   seatNumber            String
+  biddings              Bidding[]
+  bids                  Bid[]
 
   @@unique([flightId, seatNumber])
   @@unique([flightId, userId])
 }
 
+model Bidding {
+  biddingId      String   @id
+  flightId       String
+  flight         Flight   @relation(fields: [flightId], references: [flightId])
+  passengerId    Int
+  passenger      Passenger @relation(fields: [passengerId], references: [passengerId])
+  seatNumber     String
+  startTime      DateTime
+  expirationTime DateTime
+  status         String
+  bids           Bid[]
+}
+
+model Bid {
+  bidId           Int      @id @default(autoincrement())
+  biddingId       String
+  bidding         Bidding  @relation(fields: [biddingId], references: [biddingId], onDelete: Cascade)
+  bidderId        Int
+  bidder          Passenger @relation(fields: [bidderId], references: [passengerId])
+  amount          Float
+  bidderSeatNumber String
+  time            DateTime
+}
 


### PR DESCRIPTION
### **Update Database Schema to Support Bidding Persistence**

This pull request updates the database schema to support persistent storage of biddings and bids, replacing previous in-memory storage solution.

**Key Changes:**
- Added new `Bidding` model to the Prisma schema
- Added new `Bid` model to the Prisma schema
- Updated `Flight` model to include a relation to `Bidding`
- Implemented cascade delete for bids when a bidding is deleted

**Testing:**

<img width="1512" alt="Screenshot 2024-07-25 at 9 49 17 AM" src="https://github.com/user-attachments/assets/f6dfd36d-c706-462d-bef2-6cddab8cddf9">
<img width="1512" alt="Screenshot 2024-07-25 at 9 49 05 AM" src="https://github.com/user-attachments/assets/a972a42d-9a53-4060-98cc-578456c78035">
